### PR TITLE
Update sample project to use newer Gradle Plugins Portal version

### DIFF
--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,7 +1,9 @@
 import com.thoughtworks.gauge.gradle.GaugeTask
 
-apply plugin: 'java'
-apply plugin: 'gauge'
+plugins {
+    id 'java'
+    id 'org.gauge' version '1.8.0'
+}
 
 group = "my-gauge-tests"
 version = "1.1.0"
@@ -10,18 +12,6 @@ description = "My Gauge Tests"
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
-
-buildscript {
-    repositories {
-        mavenCentral()
-        jcenter()
-    }
-    dependencies {
-        // For local development
-        classpath fileTree(include: ['*.jar'], dir: "$projectDir/../plugin/build/libs")
-        classpath 'com.thoughtworks.gauge.gradle:gauge-gradle-plugin:+'
-    }
-}
 
 repositories {
     mavenCentral()

--- a/sample/env/default/default.properties
+++ b/sample/env/default/default.properties
@@ -3,10 +3,10 @@
 
 # sample_key = sample_value
 
-#The path to the gauge reports directory. Should be either relative to the project directory or an absolute path
+# The path to the gauge reports directory. Should be either relative to the project directory or an absolute path
 gauge_reports_dir = reports
 
-#Set as false if gauge reports should not be overwritten on each execution. A new time-stamped directory will be created on each execution.
+# Set as false if gauge reports should not be overwritten on each execution. A new time-stamped directory will be created on each execution.
 overwrite_reports = true
 
 # Set to false to disable screenshots on failure in reports.
@@ -14,3 +14,19 @@ screenshot_on_failure = true
 
 # The path to the gauge logs directory. Should be either relative to the project directory or an absolute path
 logs_directory = logs
+
+# Set to true to use multithreading for parallel execution
+enable_multithreading = false
+
+# Possible values for this property are 'suite', 'spec' or 'scenario'.
+# 'scenario' clears the objects after the execution of each scenario, new objects are created for next execution.
+gauge_clear_state_level = scenario
+
+# The path the gauge specifications directory. Takes a comma separated list of specification files/directories.
+gauge_specs_dir = specs
+
+# The default delimiter used read csv files.
+csv_delimiter = ,
+
+# Allows steps to be written in multiline
+allow_multiline_step = false


### PR DESCRIPTION
Updates the included sample code to refer to the version of the plugin now released to the Gradle Plugins Portal in #2; using modern Gradle Plugins DSL and dependency declarations.

Also corrects the `default.properties` to have the standard defaults you now get with `gauge init java`.