### PR TITLE
Remove IntelliJ plugin; replace with Idea plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,8 @@
 plugins {
-    id "org.jetbrains.intellij" version "0.4.7"
     id "java"
+    id "idea"
 }
+
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 


### PR DESCRIPTION
I don't think the use of `org.jetbrains.intellij` plugin added in dfdb41a6a1341d481fdeb026b09a252e717f774d was intentional. [This plugin](https://plugins.gradle.org/plugin/org.jetbrains.intellij) is intended for developing IDEA add-ins and involves downloading hundreds of MB of dependencies on JetBrains IDE versions.

I suspect the intention was to add the `idea` plugin to [auto-generate IDEA project files](https://docs.gradle.org/current/userguide/idea_plugin.html).