### PR TITLE
Fix Travis CI builds to run both JDK8 and 11 correctly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
-os:
-  - linux
+os: linux
 
 language: java
 
 jdk:
-  - oraclejdk8
-  - oraclejdk11
+  - openjdk8
+  - openjdk11
 
 script:
   - ./gradlew clean build


### PR DESCRIPTION
Travis builds were previously failing for JDK8 because oraclejdk8 installation is not supported on Travis' default Xenial distribution; this switches them to `openjdk` which works correctly.