### PR TITLE
Adds the ability to specify custom environment variables

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -99,8 +99,10 @@ gauge {
     tags = 'tag1'
     additionalFlags = '--verbose'
     gaugeRoot = '/opt/gauge'
+    // additional environment variables to pass onto the gauge process
+    environment("gauge_reports_dir", "custom/reports/")
+    environment("logs_directory", "custom/logs/")
 }
-
 ````
 
 ## Usage
@@ -131,15 +133,15 @@ Note : Pass specsDir parameter as the last one.
 ### All additional Properties
 The following plugin properties can be additionally set:
 
-|Property name|Usage|Description|
-|-------------|-----|-----------|
-|specsDir| -PspecsDir=specs| Gauge specs directory path. Required for executing specs|
-|tags    | -Ptags="tag1 & tag2" |Filter specs by specified tags expression|
-|inParallel| -PinParallel=true | Execute specs in parallel|
-|nodes    | -Pnodes=3 | Number of parallel execution streams. Use with ```parallel```|
-|env      | -Penv=qa  | gauge env to run against  |
-|additionalFlags| -PadditionalFlags="--verbose" | Add additional gauge flags to execution|
-|gaugeRoot| -PgaugeRoot="/opt/gauge" | Path to gauge installation root|
+| Property name   | Usage                         | Description                                                   |
+|-----------------|-------------------------------|---------------------------------------------------------------|
+| specsDir        | -PspecsDir=specs              | Gauge specs directory path. Required for executing specs      |
+| tags            | -Ptags="tag1 & tag2"          | Filter specs by specified tags expression                     |
+| inParallel      | -PinParallel=true             | Execute specs in parallel                                     |
+| nodes           | -Pnodes=3                     | Number of parallel execution streams. Use with ```parallel``` |
+| env             | -Penv=qa                      | gauge env to run against                                      |
+| additionalFlags | -PadditionalFlags="--verbose" | Add additional gauge flags to execution                       |
+| gaugeRoot       | -PgaugeRoot="/opt/gauge"      | Path to gauge installation root                               |
 
 ### Adding/configuring custom Gauge tasks
 It is possible to define new custom Gauge tasks specific for different environments. For example,
@@ -184,4 +186,4 @@ includeBuild {PATH_TO_GRADLE_PLUGIN}
 
 ## License
 
-Gauge is released under the Apache License, Version 2.0. See [LICENSE](LICENSE) for the full license text.
+Gauge is released under the Apache License, Version 2.0. See [LICENSE](LICENSE.txt) for the full license text.

--- a/plugin.properties
+++ b/plugin.properties
@@ -1,7 +1,7 @@
 siteUrl=https://github.com/getgauge/gauge-gradle-plugin
 gitUrl=https://github.com/getgauge/gauge-gradle-plugin.git
 
-version=1.8.2
+version=1.9.0
 name=gauge-gradle-plugin
 displayName=Gauge
 description=Gradle plugin for Gauge, the open source test automation tool developed by ThoughtWorks.

--- a/plugin/src/main/java/com/thoughtworks/gauge/gradle/GaugeExtension.java
+++ b/plugin/src/main/java/com/thoughtworks/gauge/gradle/GaugeExtension.java
@@ -6,6 +6,9 @@
 
 package com.thoughtworks.gauge.gradle;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public class GaugeExtension {
 
     private String specsDir;
@@ -16,6 +19,7 @@ public class GaugeExtension {
     private String classpath;
     private String additionalFlags;
     private String gaugeRoot;
+    private Map<String, String> environmentVariables = new HashMap<>();
 
     public String getSpecsDir() {
         return specsDir;
@@ -79,5 +83,13 @@ public class GaugeExtension {
 
     public void setGaugeRoot(String gaugeRoot) {
         this.gaugeRoot = gaugeRoot;
+    }
+
+    Map<String, String> getEnvironmentVariables() {
+        return environmentVariables;
+    }
+
+    public void environment(String key, String value) {
+        this.environmentVariables.put(key, value);
     }
 }

--- a/plugin/src/main/java/com/thoughtworks/gauge/gradle/GaugePlugin.java
+++ b/plugin/src/main/java/com/thoughtworks/gauge/gradle/GaugePlugin.java
@@ -17,7 +17,10 @@ public class GaugePlugin implements Plugin<Project> {
     @Override
     public void apply(Project project) {
         project.getExtensions().create(GAUGE, GaugeExtension.class);
-        project.getTasks().create(GAUGE, GaugeTask.class);
+        project.getTasks().create(GAUGE, GaugeTask.class, task -> {
+            task.setGroup("verification");
+            task.setDescription("Runs the Gauge test suite.");
+        });
         project.getTasks().create(CLASSPATH, ClasspathTask.class);
     }
 }

--- a/plugin/src/main/java/com/thoughtworks/gauge/gradle/GaugeTask.java
+++ b/plugin/src/main/java/com/thoughtworks/gauge/gradle/GaugeTask.java
@@ -17,6 +17,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 @SuppressWarnings("WeakerAccess")
 public class GaugeTask extends Test {
@@ -31,6 +34,13 @@ public class GaugeTask extends Test {
 
         ProcessBuilderFactory processBuilderFactory = new ProcessBuilderFactory(extension, project);
         ProcessBuilder builder = processBuilderFactory.create();
+        if (null != extension) {
+            builder.environment().putAll(
+                    extension.getEnvironmentVariables().entrySet().stream()
+                            .filter(variable -> !builder.environment().containsKey(variable.getKey()))
+                            .filter(variable -> Objects.nonNull(variable.getValue()))
+                            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
+        }
         log.info("Executing command => " + builder.command());
 
         try {

--- a/plugin/src/test/java/com/thoughtworks/gauge/gradle/GaugeExtensionTest.java
+++ b/plugin/src/test/java/com/thoughtworks/gauge/gradle/GaugeExtensionTest.java
@@ -4,7 +4,10 @@ import org.gradle.api.Project;
 import org.gradle.testfixtures.ProjectBuilder;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public class GaugeExtensionTest {
 
@@ -24,5 +27,6 @@ public class GaugeExtensionTest {
         assertNull(gauge.getClasspath());
         assertNull(gauge.getAdditionalFlags());
         assertNull(gauge.getGaugeRoot());
+        assertTrue(gauge.getEnvironmentVariables().isEmpty());
     }
 }

--- a/plugin/src/test/java/com/thoughtworks/gauge/gradle/GaugePluginTest.java
+++ b/plugin/src/test/java/com/thoughtworks/gauge/gradle/GaugePluginTest.java
@@ -10,7 +10,9 @@ import org.junit.Test;
 
 import java.util.SortedMap;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class GaugePluginTest {
     private static final String GAUGE = "gauge";
@@ -37,7 +39,7 @@ public class GaugePluginTest {
         SortedMap<String, Task> tasksMap = tasks.getAsMap();
         Task gauge = tasksMap.get(GAUGE);
         Task classpath = tasksMap.get("classpath");
-
+        assertEquals("verification", gauge.getGroup());
         assertTrue(gauge instanceof GaugeTask);
         assertTrue(classpath instanceof ClasspathTask);
     }

--- a/plugin/src/test/java/com/thoughtworks/gauge/gradle/GaugeTaskTest.java
+++ b/plugin/src/test/java/com/thoughtworks/gauge/gradle/GaugeTaskTest.java
@@ -65,6 +65,7 @@ public class GaugeTaskTest {
         gauge.setAdditionalFlags(VERBOSE_FLAG);
         gauge.setSpecsDir(SPECS_FOLDER);
         gauge.setGaugeRoot(GAUGE_ROOT);
+        gauge.environment("key", "value");
         task.executeGaugeSpecs(process);
     }
 

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -2,7 +2,7 @@ import com.thoughtworks.gauge.gradle.GaugeTask
 
 plugins {
     id 'java'
-    id 'org.gauge' version '1.8.1'
+    id 'org.gauge' version '1.8.2'
 }
 
 group = "my-gauge-tests"


### PR DESCRIPTION
Problem:
We'd like to be able to pass in custom environment variables via gradle task based on the gradle properties. 

Changes:
- Updates groupName and description for gauge task
- Adds the option to add environment keys to gauge extension tasks

E.g. 
```
gauge {
	...
	environment "key" "value"
}
```

These environment variables can be set outside of gradle but we'd like to control the value based on the properties that are provided for the project run.
