### PR TITLE
build: build using Java 25, target Java 17, test against Gradle 7-9 and Java 17/21/25

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,24 +14,21 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
+        java-test-version: [ 17, 21, 25 ]
+      fail-fast: false
     steps:
     - uses: actions/checkout@v7
     - uses: actions/setup-java@v5
       with:
         distribution: 'temurin'
-        java-version: '17' # should be same as project version
-        cache: 'gradle'
+        java-version: | # last version takes precedence as default
+          ${{ matrix.java-test-version }}
+          25
+        cache: gradle
     - uses: getgauge/setup-gauge@master
       with:
         gauge-plugins: java, html-report, xml-report
     - uses: gradle/actions/setup-gradle@v6
-    - name: Build with Gradle on ubuntu
-      if: matrix.os != 'windows-latest'
+    - name: Build with Gradle
       run: |
-        ./gradlew build
-        ./gradlew gaugeValidate gaugeDevRepeat
-    - name: Build with Gradle on windows
-      if: matrix.os == 'windows-latest'
-      run: |
-        gauge config runner_connection_timeout 300000
-        .\gradlew.bat build && .\gradlew.bat gaugeValidate gaugeDevRepeat
+        ./gradlew check -PtestToolchainJdkVersion=${{ matrix.java-test-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,8 @@ jobs:
       - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: '21'
+          java-version: '25' # Version for gradle to run with
+          cache: 'gradle'
       - uses: getgauge/setup-gauge@master
         with:
           gauge-plugins: java, html-report, xml-report

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,8 @@ plugins {
     id 'base'
 }
 
-tasks.configureEach { task ->
-    dependsOn(gradle.includedBuild("plugin").task(":${task.name}"))
+["assemble", "check", "build"].each { task ->
+    tasks.named(task) {
+        dependsOn(gradle.includedBuild("plugin").task(":$task"))
+    }
 }

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -8,14 +8,25 @@ plugins {
 group = "org.gauge.gradle"
 
 repositories {
-    mavenLocal()
     mavenCentral()
 }
 
+def targetJavaVersion = 17
+def defaultToolchainJdkVersion = JavaLanguageVersion.of(25)
+def testToolchainJdkVersion = providers.gradleProperty("testToolchainJdkVersion")
+        .map(JavaLanguageVersion::of)
+        .orElse(defaultToolchainJdkVersion)
+
+logger.lifecycle("Build targets $targetJavaVersion using JDK $defaultToolchainJdkVersion (test with JDK ${testToolchainJdkVersion.get()})")
+
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(17)
+        languageVersion = defaultToolchainJdkVersion
     }
+}
+
+tasks.withType(JavaCompile).configureEach {
+    options.release.set(targetJavaVersion)
 }
 
 pmd {
@@ -43,6 +54,9 @@ testing {
             targets {
                 all {
                     testTask.configure {
+                        javaLauncher = javaToolchains.launcherFor {
+                            languageVersion = testToolchainJdkVersion
+                        }
                         shouldRunAfter(tasks.named("test"))
                     }
                 }
@@ -52,6 +66,9 @@ testing {
 }
 
 tasks.withType(Test).configureEach {
+    javaLauncher = javaToolchains.launcherFor {
+        languageVersion = testToolchainJdkVersion
+    }
     testLogging {
         showStandardStreams = true
         showStackTraces = true

--- a/plugin/src/integrationTest/java/org/gauge/gradle/Base.java
+++ b/plugin/src/integrationTest/java/org/gauge/gradle/Base.java
@@ -7,12 +7,15 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Objects;
+
 import org.apache.commons.io.FileUtils;
 import org.gradle.testkit.runner.GradleRunner;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.io.TempDir;
 
 abstract class Base {
+
+    public static final String SUPPORTED_GRADLE_VERSIONS_FOR_CURRENT_JVM = "org.gauge.gradle.GradleTestVersion#supportedVersionsForCurrentJvm";
 
     @TempDir
     File testProjectDir;
@@ -56,20 +59,20 @@ abstract class Base {
               id 'org.gauge'
             }
             repositories {
-              mavenLocal()
               mavenCentral()
             }
             dependencies {
               testImplementation 'com.thoughtworks.gauge:gauge-java:+'
             }
             tasks.withType(AbstractTestTask).configureEach {
-                failOnNoDiscoveredTests = false
+                if (GradleVersion.current().version >= '9') failOnNoDiscoveredTests = false
             }
             """;
     }
 
-    protected GradleRunner defaultGradleRunner() {
+    protected GradleRunner defaultGradleRunner(GradleTestVersion gradle) {
         return GradleRunner.create()
+            .withGradleVersion(gradle.version)
             .withProjectDir(testProjectDir)
             .withPluginClasspath();
     }

--- a/plugin/src/integrationTest/java/org/gauge/gradle/ClasspathTaskTest.java
+++ b/plugin/src/integrationTest/java/org/gauge/gradle/ClasspathTaskTest.java
@@ -8,21 +8,22 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import org.gradle.testkit.runner.BuildResult;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class ClasspathTaskTest extends Base {
 
-    @Test
-    void testCanRunGaugeClasspathTaskWithGaugeDependency() throws IOException {
+    @ParameterizedTest
+    @MethodSource(SUPPORTED_GRADLE_VERSIONS_FOR_CURRENT_JVM)
+    void testCanRunGaugeClasspathTaskWithGaugeDependency(GradleTestVersion gradle) throws IOException {
         copyGaugeFixtureToTemp();
         // Given plugin is applied without gauge extension
         // And gauge-java dependency included
         writeFile(buildFilePath, getApplyPluginsBlock());
         // Then I should be able to run the classpath task
-        BuildResult result = defaultGradleRunner().withArguments(GAUGE_CLASSPATH_TASK).build();
+        BuildResult result = defaultGradleRunner(gradle).withArguments(GAUGE_CLASSPATH_TASK).build();
         assertEquals(SUCCESS, result.task(":" + GAUGE_CLASSPATH_TASK).getOutcome());
         assertThat(result.getOutput(), containsString("gauge-java"));
         assertThat(result.getOutput(), containsString("assertj-core"));
     }
-
 }

--- a/plugin/src/integrationTest/java/org/gauge/gradle/GaugeTaskTest.java
+++ b/plugin/src/integrationTest/java/org/gauge/gradle/GaugeTaskTest.java
@@ -4,8 +4,7 @@ import static org.gauge.gradle.GaugeConstants.GAUGE_TASK;
 import static org.gradle.testkit.runner.TaskOutcome.FAILED;
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
@@ -13,7 +12,8 @@ import java.io.IOException;
 import java.nio.file.Path;
 import org.gradle.testkit.runner.BuildResult;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class GaugeTaskTest extends Base {
 
@@ -22,65 +22,81 @@ class GaugeTaskTest extends Base {
         copyGaugeFixtureToTemp();
     }
 
-    @Test
-    void testCanRunGaugeTasksWithDefaultConfigurations() throws IOException {
+    @ParameterizedTest
+    @MethodSource(SUPPORTED_GRADLE_VERSIONS_FOR_CURRENT_JVM)
+    void testCanRunGaugeTasksWithDefaultConfigurations(GradleTestVersion gradle) throws IOException {
         // Given plugin is applied
         writeFile(buildFilePath, getApplyPluginsBlock());
         // Then I should be able to run the gauge task
-        BuildResult result = defaultGradleRunner().withArguments(GAUGE_TASK).build();
+        BuildResult result = defaultGradleRunner(gradle).withArguments(GAUGE_TASK).build();
         assertEquals(SUCCESS, result.task(GAUGE_TASK_PATH).getOutcome());
         assertThat(result.getOutput(), containsString("Successfully generated html-report"));
     }
 
-    @Test
-    void testCanRunGaugeTestsWhenDirPropertySet() throws IOException {
-        final File subProject = new File(Path.of(defaultGradleRunner().getProjectDir().getPath(), "subProject").toString());
+    @ParameterizedTest
+    @MethodSource(SUPPORTED_GRADLE_VERSIONS_FOR_CURRENT_JVM)
+    void testCanRunGaugeTestsWhenDirPropertySet(GradleTestVersion gradle) throws IOException {
+        final File subProject = new File(Path.of(defaultGradleRunner(gradle).getProjectDir().getPath(), "subProject").toString());
         copyGaugeFixtureToTemp(subProject, "simple-project");
         // Given plugin is applied
         writeFile(buildFilePath, getApplyPluginsBlock());
         // Then I should be able to run the gauge task
-        BuildResult resultWithDirProperty = defaultGradleRunner().withArguments(GAUGE_TASK, "-Pdir=" + subProject.getAbsolutePath()).build();
+        BuildResult resultWithDirProperty = defaultGradleRunner(gradle).withArguments(GAUGE_TASK, "-Pdir=" + subProject.getAbsolutePath()).build();
         assertEquals(SUCCESS, resultWithDirProperty.task(GAUGE_TASK_PATH).getOutcome());
     }
 
-    @Test
-    void testCanRunGaugeTestsWhenDirSetInExtension() throws IOException {
-        final File subProject = new File(Path.of(defaultGradleRunner().getProjectDir().getPath(), "subProject").toString());
+    @ParameterizedTest
+    @MethodSource(SUPPORTED_GRADLE_VERSIONS_FOR_CURRENT_JVM)
+    void testCanRunGaugeTestsWhenDirSetInExtension(GradleTestVersion gradle) throws IOException {
+        final File subProject = new File(Path.of(defaultGradleRunner(gradle).getProjectDir().getPath(), "subProject").toString());
         copyGaugeFixtureToTemp(subProject, "simple-project");
         // Given plugin is applied
-        writeFile(buildFilePath, getApplyPluginsBlock() + "gauge {dir=\"subProject\"}");
+        writeFile(buildFilePath, getApplyPluginsBlock() + """
+                gauge {
+                  dir = "subProject"
+                }
+                """);
         // Then I should be able to run the gauge task
-        BuildResult resultWithExtensionProperty = defaultGradleRunner().withArguments(GAUGE_TASK).build();
+        BuildResult resultWithExtensionProperty = defaultGradleRunner(gradle).withArguments(GAUGE_TASK).build();
         assertEquals(SUCCESS, resultWithExtensionProperty.task(GAUGE_TASK_PATH).getOutcome());
     }
 
-    @Test
-    void testCanRunGaugeTestsWhenSpecsDirSet() throws IOException {
+    @ParameterizedTest
+    @MethodSource(SUPPORTED_GRADLE_VERSIONS_FOR_CURRENT_JVM)
+    void testCanRunGaugeTestsWhenSpecsDirSet(GradleTestVersion gradle) throws IOException {
         // Given plugin is applied
         // When specsDir is set in the extension with an invalid/non-existing directory
-        writeFile(buildFilePath, getApplyPluginsBlock() + "gauge {specsDir=\"invalid\"}\n");
+        writeFile(buildFilePath, getApplyPluginsBlock() + """
+                gauge {
+                  specsDir= "invalid"
+                }
+                """);
         // Then I should be able to run the gauge task
-        BuildResult resultWithExtension = defaultGradleRunner().withArguments(GAUGE_TASK).buildAndFail();
+        BuildResult resultWithExtension = defaultGradleRunner(gradle).withArguments(GAUGE_TASK).buildAndFail();
         // And I should get a failure with missing specs directory
         assertEquals(FAILED, resultWithExtension.task(GAUGE_TASK_PATH).getOutcome());
         assertThat(resultWithExtension.getOutput(), containsString("Specs directory invalid does not exist."));
         // When specsDir is set to multiple specs directory with one being an invalid/non-existing directory
-        BuildResult resultWithProperty = defaultGradleRunner().withArguments(GAUGE_TASK, "-PspecsDir=specs specs2").buildAndFail();
+        BuildResult resultWithProperty = defaultGradleRunner(gradle).withArguments(GAUGE_TASK, "-PspecsDir=specs specs2").buildAndFail();
         // And I should get a failure with missing specs directory
         assertEquals(FAILED, resultWithProperty.task(GAUGE_TASK_PATH).getOutcome());
         assertThat(resultWithProperty.getOutput(), containsString("Specs directory specs2 does not exist."));
     }
 
-    @Test
-    void testCanRunGaugeTestsWhenEnvVariablesAndAdditionalFlagsSet() throws IOException {
+    @ParameterizedTest
+    @MethodSource(SUPPORTED_GRADLE_VERSIONS_FOR_CURRENT_JVM)
+    void testCanRunGaugeTestsWhenEnvVariablesAndAdditionalFlagsSet(GradleTestVersion gradle) throws IOException {
         // Given plugin is applied
         // When environmentVariables is set in extension
         // And additionalFlags include the --verbose flag
-        writeFile(buildFilePath, getApplyPluginsBlock()
-            + "gauge {environmentVariables=['customVariable': 'customValue']\n"
-            + "additionalFlags='--simple-console --verbose'}\n");
+        writeFile(buildFilePath, getApplyPluginsBlock() + """
+                gauge {
+                  environmentVariables = ['customVariable': 'customValue']
+                  additionalFlags = '--simple-console --verbose'
+                }
+                """);
         // Then I should be able to run the gauge task
-        BuildResult resultWithExtension = defaultGradleRunner().withArguments(GAUGE_TASK).build();
+        BuildResult resultWithExtension = defaultGradleRunner(gradle).withArguments(GAUGE_TASK).build();
         assertEquals(SUCCESS, resultWithExtension.task(GAUGE_TASK_PATH).getOutcome());
         // And I should see custom environment was set correctly
         assertThat(resultWithExtension.getOutput(), containsString("customVariable is set to customValue in build.gradle"));
@@ -88,25 +104,29 @@ class GaugeTaskTest extends Base {
         assertThat(resultWithExtension.getOutput(), containsString("The word \"gauge\" has \"3\" vowels."));
     }
 
-    @Test
-    void testCanRunGaugeTestsWhenInParallelSet() throws IOException {
+    @ParameterizedTest
+    @MethodSource(SUPPORTED_GRADLE_VERSIONS_FOR_CURRENT_JVM)
+    void testCanRunGaugeTestsWhenInParallelSet(GradleTestVersion gradle) throws IOException {
         // Given plugin is applied
         // When inParallel=true is set in extension
         // And additionalFlags include the --simple-console flag
-        writeFile(buildFilePath, getApplyPluginsBlock()
-            + "gauge {specsDir='specs multipleSpecs'\n"
-            + "inParallel=true\n"
-            + "nodes=2\n"
-            + "additionalFlags='--simple-console'}\n");
+        writeFile(buildFilePath, getApplyPluginsBlock() + """
+                gauge {
+                  specsDir = 'specs multipleSpecs'
+                  inParallel = true
+                  nodes = 2
+                  additionalFlags = '--simple-console --verbose'
+                }
+                """);
         // Then I should be able to run the gauge task
-        BuildResult resultWithExtension = defaultGradleRunner().withArguments(GAUGE_TASK).build();
+        BuildResult resultWithExtension = defaultGradleRunner(gradle).withArguments(GAUGE_TASK).build();
         assertEquals(SUCCESS, resultWithExtension.task(GAUGE_TASK_PATH).getOutcome());
         // And I should see tests running in default parallel streams
         assertThat(resultWithExtension.getOutput(), containsString("Executing in 2 parallel streams."));
         // And I should see all 4 specifications were executed
         assertThat(resultWithExtension.getOutput(), containsString("Specifications:\t4 executed"));
         // When nodes=3 project property is set
-        BuildResult resultWithProperty = defaultGradleRunner().withArguments(GAUGE_TASK, "-Pnodes=3").build();
+        BuildResult resultWithProperty = defaultGradleRunner(gradle).withArguments(GAUGE_TASK, "-Pnodes=3").build();
         assertEquals(SUCCESS, resultWithProperty.task(GAUGE_TASK_PATH).getOutcome());
         // Then I should see tests running in 2 parallel streams
         assertThat(resultWithProperty.getOutput(), containsString("Executing in 3 parallel streams."));
@@ -114,26 +134,30 @@ class GaugeTaskTest extends Base {
         assertThat(resultWithProperty.getOutput(), containsString("Specifications:\t4 executed"));
     }
 
-    @Test
-    void testCanRunGaugeTestsWhenTagsSet() throws IOException {
+    @ParameterizedTest
+    @MethodSource(SUPPORTED_GRADLE_VERSIONS_FOR_CURRENT_JVM)
+    void testCanRunGaugeTestsWhenTagsSet(GradleTestVersion gradle) throws IOException {
         // Given plugin is applied
         // When inParallel=true is set in extension
         // And additionalFlags include the --simple-console flag
         // And tags=example1 set to run
-        writeFile(buildFilePath, getApplyPluginsBlock()
-            + "gauge {specsDir='specs multipleSpecs'\n"
-            + "inParallel=true\n"
-            + "additionalFlags='--simple-console'\n"
-            + "tags='example1'}");
+        writeFile(buildFilePath, getApplyPluginsBlock() + """
+                gauge {
+                  specsDir='specs multipleSpecs'
+                  inParallel = true
+                  additionalFlags = '--simple-console --verbose'
+                  tags = 'example1'
+                }
+                """);
         // Then I should be able to run the gauge task
-        BuildResult resultWithExtension = defaultGradleRunner().withArguments(GAUGE_TASK).build();
+        BuildResult resultWithExtension = defaultGradleRunner(gradle).withArguments(GAUGE_TASK).build();
         assertEquals(SUCCESS, resultWithExtension.task(GAUGE_TASK_PATH).getOutcome());
         // And I should see tests running only with specified tag
         assertThat(resultWithExtension.getOutput(), containsString("parallel streams."));
         assertThat(resultWithExtension.getOutput(), containsString("Specifications:\t2 executed"));
         // When nodes=2 project property is set
         // And tags project property is set to run either scenarios with example1 or example2 tags
-        BuildResult resultWithProperty = defaultGradleRunner().withArguments(GAUGE_TASK, "-Pnodes=2", "-Ptags=example1|example2").build();
+        BuildResult resultWithProperty = defaultGradleRunner(gradle).withArguments(GAUGE_TASK, "-Pnodes=2", "-Ptags=example1|example2").build();
         assertEquals(SUCCESS, resultWithProperty.task(GAUGE_TASK_PATH).getOutcome());
         // Then I should see tests running in 2 parallel streams
         assertThat(resultWithProperty.getOutput(), containsString("Executing in 2 parallel streams."));
@@ -141,52 +165,58 @@ class GaugeTaskTest extends Base {
         assertThat(resultWithProperty.getOutput(), containsString("Specifications:\t3 executed"));
     }
 
-    @Test
-    void testCanRunGaugeTestsWhenEnvSet() throws IOException {
+    @ParameterizedTest
+    @MethodSource(SUPPORTED_GRADLE_VERSIONS_FOR_CURRENT_JVM)
+    void testCanRunGaugeTestsWhenEnvSet(GradleTestVersion gradle) throws IOException {
         // Given plugin is applied
         // When inParallel=true is set in extension
         // And additionalFlags include the --verbose flag
         // When env is set to invalid/non-existing
-        writeFile(buildFilePath, getApplyPluginsBlock()
-            + "gauge {inParallel=true\n"
-            + "additionalFlags='--simple-console'\n"
-            + "env='invalid'}");
+        writeFile(buildFilePath, getApplyPluginsBlock() + """
+                gauge {
+                  inParallel = true
+                  additionalFlags = '--simple-console --verbose'
+                  env = 'invalid'
+                }
+                """);
         // Then I should be able to run the gauge task
-        BuildResult resultWithExtension = defaultGradleRunner().withArguments(GAUGE_TASK).buildAndFail();
+        BuildResult resultWithExtension = defaultGradleRunner(gradle).withArguments(GAUGE_TASK).buildAndFail();
         assertEquals(FAILED, resultWithExtension.task(GAUGE_TASK_PATH).getOutcome());
         // And I should see environment does not exist error
         assertThat(resultWithExtension.getOutput(), containsString("invalid environment does not exist"));
         // When env=dev project property is set
-        BuildResult resultWithProperty = defaultGradleRunner().withArguments(GAUGE_TASK, "-Penv=dev").build();
+        BuildResult resultWithProperty = defaultGradleRunner(gradle).withArguments(GAUGE_TASK, "-Penv=dev").build();
         assertEquals(SUCCESS, resultWithProperty.task(GAUGE_TASK_PATH).getOutcome());
         // And I should see tests ran against the dev environment
         assertThat(resultWithProperty.getOutput(), containsString(getExpectedReportPath("dev")));
     }
 
-    @Test
-    void testCanRunGaugeTestsWhenRepeatFlagSet() throws IOException {
+    @ParameterizedTest
+    @MethodSource(SUPPORTED_GRADLE_VERSIONS_FOR_CURRENT_JVM)
+    void testCanRunGaugeTestsWhenRepeatFlagSet(GradleTestVersion gradle) throws IOException {
         // Given plugin is applied
         // When inParallel=true is set in extension
         // And additionalFlags include the --simple-console flag
         // When env is set to dev
-        writeFile(buildFilePath, getApplyPluginsBlock()
-            + "gauge {inParallel=true\n"
-            + "additionalFlags='--simple-console'\n"
-            + "nodes=2\n"
-            + "env='dev'}");
+        writeFile(buildFilePath, getApplyPluginsBlock() + """
+                gauge {
+                  additionalFlags = '--simple-console --verbose'
+                  env = 'dev'
+                }
+                """);
         // Then I should be able to run the gauge task
-        BuildResult resultWithExtension = defaultGradleRunner().withArguments(GAUGE_TASK, "--info").build();
+        BuildResult resultWithExtension = defaultGradleRunner(gradle).withArguments(GAUGE_TASK, "--info").build();
         assertEquals(SUCCESS, resultWithExtension.task(GAUGE_TASK_PATH).getOutcome());
         // And I should see environment and parallel flags with specs in the command
-        assertThat(resultWithExtension.getOutput(), containsString("--simple-console --parallel --n 2 --env dev specs"));
+        assertThat(resultWithExtension.getOutput(), containsString("--simple-console --verbose --env dev specs"));
         // When additionalFlags include the --repeat flag
-        BuildResult resultWithProperty = defaultGradleRunner()
-            .withArguments(GAUGE_TASK, "-PadditionalFlags=--repeat --simple-console", "--info").build();
+        BuildResult resultWithProperty = defaultGradleRunner(gradle)
+                .withArguments(GAUGE_TASK, "-PadditionalFlags=--repeat --simple-console --verbose", "--info").build();
         assertEquals(SUCCESS, resultWithProperty.task(GAUGE_TASK_PATH).getOutcome());
         // Then I should not see environment and parallel flags and specs include the command
-        assertThat(resultWithProperty.getOutput(), not(containsString("--parallel --n 2 --env dev specs")));
+        assertThat(resultWithProperty.getOutput(), not(containsString("--env dev specs")));
         // And I should only see repeat and simple-console included
-        assertThat(resultWithProperty.getOutput(), containsString("--repeat --simple-console"));
+        assertThat(resultWithProperty.getOutput(), containsString("--repeat --simple-console --verbose"));
         // And I should see tests ran against the dev environment
         assertThat(resultWithProperty.getOutput(), containsString(getExpectedReportPath("dev")));
     }

--- a/plugin/src/integrationTest/java/org/gauge/gradle/GaugeValidateTaskTest.java
+++ b/plugin/src/integrationTest/java/org/gauge/gradle/GaugeValidateTaskTest.java
@@ -8,25 +8,32 @@ import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
+
 import org.gradle.testkit.runner.BuildResult;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class GaugeValidateTaskTest extends Base {
 
-    @Test
-    void testCanRunGaugeValidateTask() throws IOException {
+    @ParameterizedTest
+    @MethodSource(SUPPORTED_GRADLE_VERSIONS_FOR_CURRENT_JVM)
+    void testCanRunGaugeValidateTask(GradleTestVersion gradle) throws IOException {
         copyGaugeFixtureToTemp();
         // Given plugin is applied without gauge extension
         writeFile(buildFilePath, getApplyPluginsBlock());
         // Then I should be able to run the classpath task
-        BuildResult result = defaultGradleRunner().withArguments(GAUGE_VALIDATE_TASK).build();
+        BuildResult result = defaultGradleRunner(gradle).withArguments(GAUGE_VALIDATE_TASK).build();
         // And I should see no validation errors
         assertEquals(SUCCESS, result.task(":" + GAUGE_VALIDATE_TASK).getOutcome());
         assertThat(result.getOutput(), containsString("No errors found."));
         // When specsDir is set in extension
         // And example4.spec contains a missing step implementation
-        writeFile(buildFilePath, getApplyPluginsBlock() + "gauge {specsDir=\"multipleSpecs/example4.spec\"}\n");
-        BuildResult resultWithExtension = defaultGradleRunner().withArguments(GAUGE_VALIDATE_TASK).buildAndFail();
+        writeFile(buildFilePath, getApplyPluginsBlock() + """
+                gauge {
+                  specsDir = "multipleSpecs/example4.spec"
+                }
+                """);
+        BuildResult resultWithExtension = defaultGradleRunner(gradle).withArguments(GAUGE_VALIDATE_TASK).buildAndFail();
         // Then I should see a failure with a validation error
         assertEquals(FAILED, resultWithExtension.task(":" + GAUGE_VALIDATE_TASK).getOutcome());
         assertThat(resultWithExtension.getOutput(), containsString("example4.spec:6 Step implementation not found"));

--- a/plugin/src/integrationTest/java/org/gauge/gradle/GradleTestVersion.java
+++ b/plugin/src/integrationTest/java/org/gauge/gradle/GradleTestVersion.java
@@ -1,0 +1,43 @@
+package org.gauge.gradle;
+
+import org.gradle.util.GradleVersion;
+
+import java.util.Arrays;
+
+public enum GradleTestVersion {
+    v7_6("7.6.6", 8, 19), // Jul 2025
+    v8_14("8.14.5", 8, 25), // May 2026
+    vCURRENT(GradleVersion.current().getVersion(), 17, 26);
+
+    final String version;
+    final int minJdk;
+    final int maxJdk;
+
+    GradleTestVersion(String version, int minJdk, int maxJdk) {
+        this.version = version;
+        this.minJdk = minJdk;
+        this.maxJdk = maxJdk;
+    }
+
+    boolean isSupportedOnCurrentJvm() {
+        int current = Runtime.version().feature();
+        return minJdk <= current && maxJdk >= current;
+    }
+
+    boolean isAtLeast(int majorVersion) {
+        return Integer.parseInt(version.split("\\.")[0]) >= majorVersion;
+    }
+
+    static GradleTestVersion[] supportedVersionsForCurrentJvm() {
+        return Arrays.stream(values()).filter(GradleTestVersion::isSupportedOnCurrentJvm).toArray(GradleTestVersion[]::new);
+    }
+
+    static GradleTestVersion[] supportedVersionsForCurrentJvmFrom(int gradleMajorVersion) {
+        return Arrays.stream(supportedVersionsForCurrentJvm()).filter(it -> it.isAtLeast(gradleMajorVersion)).toArray(GradleTestVersion[]::new);
+    }
+
+    @Override
+    public String toString() {
+        return version;
+    }
+}

--- a/plugin/src/integrationTest/java/org/gauge/gradle/UpToDateTaskTest.java
+++ b/plugin/src/integrationTest/java/org/gauge/gradle/UpToDateTaskTest.java
@@ -7,39 +7,43 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import org.gradle.testkit.runner.GradleRunner;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class UpToDateTaskTest extends Base {
 
-    @Test
-    void testGaugeTaskIsNotCached() throws IOException {
+    @ParameterizedTest
+    @MethodSource(SUPPORTED_GRADLE_VERSIONS_FOR_CURRENT_JVM)
+    void testGaugeTaskIsNotCached(GradleTestVersion gradle) throws IOException {
         copyGaugeFixtureToTemp();
         // Given plugin is applied
         writeFile(buildFilePath, getApplyPluginsBlock());
         // Then I should be able to run the gauge task
-        GradleRunner runner = defaultGradleRunner().withArguments(GAUGE_TASK);
+        GradleRunner runner = defaultGradleRunner(gradle).withArguments(GAUGE_TASK);
         assertEquals(SUCCESS, runner.build().task(GAUGE_TASK_PATH).getOutcome());
         assertEquals(SUCCESS, runner.build().task(GAUGE_TASK_PATH).getOutcome());
     }
 
-    @Test
-    void testGaugeValidateTaskIsNotCached() throws IOException {
+    @ParameterizedTest
+    @MethodSource(SUPPORTED_GRADLE_VERSIONS_FOR_CURRENT_JVM)
+    void testGaugeValidateTaskIsNotCached(GradleTestVersion gradle) throws IOException {
         copyGaugeFixtureToTemp();
         // Given plugin is applied
         writeFile(buildFilePath, getApplyPluginsBlock());
         // Then I should be able to run the gauge task
-        GradleRunner runner = defaultGradleRunner().withArguments("gaugeValidate");
+        GradleRunner runner = defaultGradleRunner(gradle).withArguments("gaugeValidate");
         assertEquals(SUCCESS, runner.build().task(":gaugeValidate").getOutcome());
         assertEquals(SUCCESS, runner.build().task(":gaugeValidate").getOutcome());
     }
 
-    @Test
-    void testGaugeClasspathTaskIsNotCached() throws IOException {
+    @ParameterizedTest
+    @MethodSource(SUPPORTED_GRADLE_VERSIONS_FOR_CURRENT_JVM)
+    void testGaugeClasspathTaskIsNotCached(GradleTestVersion gradle) throws IOException {
         copyGaugeFixtureToTemp();
         // Given plugin is applied
         writeFile(buildFilePath, getApplyPluginsBlock());
         // Then I should be able to run the gauge task
-        GradleRunner runner = defaultGradleRunner().withArguments(GAUGE_CLASSPATH_TASK);
+        GradleRunner runner = defaultGradleRunner(gradle).withArguments(GAUGE_CLASSPATH_TASK);
         assertEquals(SUCCESS, runner.build().task(":" + GAUGE_CLASSPATH_TASK).getOutcome());
         assertEquals(SUCCESS, runner.build().task(":" + GAUGE_CLASSPATH_TASK).getOutcome());
     }

--- a/plugin/src/main/java/org/gauge/gradle/GaugeCommand.java
+++ b/plugin/src/main/java/org/gauge/gradle/GaugeCommand.java
@@ -4,11 +4,7 @@ import org.gradle.api.Project;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /**
  * Represents a Gauge command and provides methods to construct command-line arguments for Gauge execution.
@@ -37,16 +33,13 @@ public class GaugeCommand {
      * @return the path to the Gauge executable
      */
     public String getExecutable() {
-        final String binary = "gauge";
         return project.hasProperty(GaugeProperty.GAUGE_ROOT.getKey())
-                ? getExecutablePath(properties.get(GaugeProperty.GAUGE_ROOT.getKey()).toString()).toString()
-                : extension.getGaugeRoot().isPresent()
-                  ? getExecutablePath(extension.getGaugeRoot().get()).toString()
-                  : binary;
+                ? getExecutablePath(properties.get(GaugeProperty.GAUGE_ROOT.getKey()).toString())
+                : extension.getGaugeRoot().map(this::getExecutablePath).getOrElse("gauge");
     }
 
-    private Path getExecutablePath(final String gaugeRoot) {
-        return Paths.get(gaugeRoot, "bin", "gauge");
+    private String getExecutablePath(final String gaugeRoot) {
+        return Paths.get(gaugeRoot, "bin", "gauge").toString();
     }
 
     /**
@@ -105,33 +98,33 @@ public class GaugeCommand {
             flags.add(GaugeProperty.IN_PARALLEL.getFlag());
             final int nodes = getNodes();
             if (nodes != 0) {
-                flags.addAll(List.of(GaugeProperty.NODES.getFlag(), nodes));
+                flags.add(GaugeProperty.NODES.getFlag());
+                flags.add(nodes);
             }
         }
         return flags;
     }
 
     private List<String> getAdditionalFlags() {
-        return project.hasProperty(GaugeProperty.ADDITIONAL_FLAGS.getKey())
-                ? getListFromString(properties.get(GaugeProperty.ADDITIONAL_FLAGS.getKey()).toString())
-                : extension.getAdditionalFlags().isPresent()
-                ? getListFromString(extension.getAdditionalFlags().get())
-                : Collections.emptyList();
+        return getListFromString(project.hasProperty(GaugeProperty.ADDITIONAL_FLAGS.getKey())
+                ? properties.get(GaugeProperty.ADDITIONAL_FLAGS.getKey()).toString()
+                : extension.getAdditionalFlags().getOrElse("")
+        );
     }
 
     private List<String> getListFromString(final String value) {
-        return Arrays.stream(value.split("\\s+")).map(String::trim).toList();
+        return Arrays.stream(value.split("\\s+")).map(String::trim).filter(s -> !s.isEmpty()).toList();
     }
 
     private int getNodes() {
         return project.hasProperty(GaugeProperty.NODES.getKey())
                 ? Integer.parseInt(properties.get(GaugeProperty.NODES.getKey()).toString())
-                : extension.getNodes().isPresent() ? extension.getNodes().get() : 0;
+                : extension.getNodes().getOrElse(0);
     }
 
     private boolean isInParallel() {
         return project.hasProperty(GaugeProperty.IN_PARALLEL.getKey())
-                ? Boolean.parseBoolean(project.getProperties().get(GaugeProperty.IN_PARALLEL.getKey()).toString())
+                ? Boolean.parseBoolean(properties.get(GaugeProperty.IN_PARALLEL.getKey()).toString())
                 : extension.getInParallel().get();
     }
 
@@ -154,7 +147,7 @@ public class GaugeCommand {
     public List<String> getTags() {
         final String tags = project.hasProperty(GaugeProperty.TAGS.getKey())
                 ? properties.get(GaugeProperty.TAGS.getKey()).toString()
-                : extension.getTags().isPresent() ? extension.getTags().get() : "";
+                : extension.getTags().getOrElse("");
         return !tags.isEmpty() ? List.of(GaugeProperty.TAGS.getFlag(), tags) : Collections.emptyList();
     }
 

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -5,17 +5,24 @@ plugins {
 }
 
 repositories {
-    mavenLocal()
     mavenCentral()
 }
 
+def defaultToolchainJdkVersion = JavaLanguageVersion.current()
+def testToolchainJdkVersion = providers.gradleProperty("testToolchainJdkVersion")
+        .map(JavaLanguageVersion::of)
+        .orElse(defaultToolchainJdkVersion)
+
+logger.lifecycle("Sample targets ${testToolchainJdkVersion.get()} using JDK ${testToolchainJdkVersion.get()}")
+
 java {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    toolchain {
+        languageVersion = testToolchainJdkVersion
+    }
 }
 
 tasks.withType(JavaCompile).configureEach {
-    options.release = 17
+    options.release = testToolchainJdkVersion.get().asInt()
 }
 
 sourceSets {
@@ -48,7 +55,7 @@ gauge {
     additionalFlags = '--verbose'
 }
 
-tasks.register('gaugeDev', GaugeTask) {
+def gaugeDev = tasks.register('gaugeDev', GaugeTask) {
     doFirst {
         gauge {
             specsDir = 'specs'
@@ -60,8 +67,8 @@ tasks.register('gaugeDev', GaugeTask) {
     }
 }
 
-tasks.register('gaugeDevRepeat', GaugeTask) {
-    dependsOn("gaugeDev")
+def gaugeDevRepeat = tasks.register('gaugeDevRepeat', GaugeTask) {
+    dependsOn(gaugeDev)
     doFirst {
         gauge {
             additionalFlags = '--repeat --simple-console'
@@ -72,3 +79,9 @@ tasks.register('gaugeDevRepeat', GaugeTask) {
 tasks.withType(AbstractTestTask).configureEach {
     failOnNoDiscoveredTests = false
 }
+
+def pluginCheck = gradle.includedBuild("plugin").task(":check")
+tasks.gaugeValidate.dependsOn(pluginCheck)
+tasks.gaugeDev.dependsOn(pluginCheck)
+
+tasks.check.dependsOn(gaugeValidate, gaugeDevRepeat)

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,10 +1,7 @@
 import org.gauge.gradle.GaugeTask
 
 plugins {
-    id 'java'
-    id 'jvm-test-suite'
     id 'org.gauge'
-    id 'pmd'
 }
 
 repositories {
@@ -19,10 +16,6 @@ java {
 
 tasks.withType(JavaCompile).configureEach {
     options.release = 17
-}
-
-pmd {
-    consoleOutput = true
 }
 
 sourceSets {

--- a/sample/settings.gradle
+++ b/sample/settings.gradle
@@ -1,6 +1,5 @@
 pluginManagement {
     repositories {
-        mavenLocal()
         gradlePluginPortal()
     }
     includeBuild "../plugin"

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,5 @@
 pluginManagement {
     repositories {
-        mavenLocal()
         gradlePluginPortal()
     }
     includeBuild "plugin"


### PR DESCRIPTION
Reworks the build and testing to
- use toolchains to always build with a canonical JDK (changed to Java 25)
- continue to target Java 17
- test against a matrix of Java versions via a Gradle property (defaults to the default toolchain version)
- test against a matrix of Gradle versions (7.x / 8.x / 9.x) to improve chances of maintaining backwards compatibility